### PR TITLE
Fix code scanning alert no. 3: Log injection

### DIFF
--- a/api/src/controllers/RoundController.ts
+++ b/api/src/controllers/RoundController.ts
@@ -48,7 +48,8 @@ router.post('/:round/duel', async (req: Request, res: Response): Promise<any> =>
     }
 
     await TournamentService.updateStandingsAndWinner(match.tournament_id)
-    console.debug('Game stats updated for game_id:', id)
+    const sanitizedId = id.replace(/\n|\r/g, "")
+    console.debug('Game stats updated for game_id:', sanitizedId)
     res.status(201).json(roundState)
   } catch (err) {
     console.error('Error executing query:', err)


### PR DESCRIPTION
Fixes [https://github.com/cristiadu/vavalm/security/code-scanning/3](https://github.com/cristiadu/vavalm/security/code-scanning/3)

To fix the log injection issue, we need to sanitize the `id` parameter before logging it. Specifically, we should remove any newline characters from the `id` to prevent log forgery. This can be done using `String.prototype.replace` to remove newline characters.

- **General fix:** Sanitize user inputs before logging them to prevent log injection.
- **Detailed fix:** Modify the code to sanitize the `id` parameter by removing newline characters before logging it.
- **Specific changes:** Update line 51 to sanitize the `id` parameter before logging it.
- **Requirements:** No new methods or definitions are needed, but we will use `String.prototype.replace` to sanitize the `id`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
