### PR TITLE
Fix code scanning alert no. 2: Log injection

### DIFF
--- a/api/src/controllers/RoundController.ts
+++ b/api/src/controllers/RoundController.ts
@@ -22,7 +22,8 @@ router.post('/:round/play', async (req: Request, res: Response): Promise<any> =>
     }
 
     await TournamentService.updateStandingsAndWinner(match.tournament_id)
-    console.debug('Game stats updated for game_id:', id)
+    const sanitizedId = String(id).replace(/\n|\r/g, "");
+    console.debug('Game stats updated for game_id:', sanitizedId)
     res.status(201).json(roundFinishedState)
   } catch (err) {
     console.error('Error executing query:', err)
@@ -48,7 +49,8 @@ router.post('/:round/duel', async (req: Request, res: Response): Promise<any> =>
     }
 
     await TournamentService.updateStandingsAndWinner(match.tournament_id)
-    console.debug('Game stats updated for game_id:', id)
+    const sanitizedId = String(id).replace(/\n|\r/g, "");
+    console.debug('Game stats updated for game_id:', sanitizedId)
     res.status(201).json(roundState)
   } catch (err) {
     console.error('Error executing query:', err)


### PR DESCRIPTION
Fixes [https://github.com/cristiadu/vavalm/security/code-scanning/2](https://github.com/cristiadu/vavalm/security/code-scanning/2)

To fix the log injection issue, we need to sanitize the `id` parameter before logging it. Since the `id` is expected to be a number, we can ensure it is a valid number and convert it to a string without any special characters or newlines. This can be done using `String.prototype.replace` to remove any newline characters from the `id` before logging it.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
