### PR TITLE
Potential fix for code scanning alert no. 50: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ "main" ]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/cristiadu/vavalm/security/code-scanning/50](https://github.com/cristiadu/vavalm/security/code-scanning/50)

To fix the issue, we will add a `permissions` block at the root level of the workflow file. This block will explicitly define the minimal permissions required for the workflow. Since the workflow only involves building, linting, and testing the project, it does not require any write permissions. The `contents: read` permission is sufficient for these operations.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
