### PR TITLE
chore: replace relative imports with @tests/ aliases, fix knip hints, update AGENTS.md

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,6 @@ venv
 
 # coverage
 **/tests/coverage
+
+# claude
+.claude/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -106,39 +106,67 @@ Never use `Pick<*ApiModel, ...>` casts inline in `toApiModel()` or controllers �
 - DB models: `PascalCase` noun — `Player`, `GameLog`, `Tournament`.
 - Contract models: same name suffixed with `ApiModel` — `PlayerApiModel`, `GameLogApiModel`.
 - Sub-shapes that appear inside a contract model also follow `*ApiModel` — e.g. `RoundStateApiModel`, `PlayerAttributesApiModel`.
-- Never invent a parallel alias (`RoundStateJson`, `RoundStatePlain`, etc.). If a plain-object cast is needed, use `Pick<*ApiModel, ...>` to derive the type from the existing contract model.
+- Never invent a parallel alias (`RoundStateJson`, `RoundStatePlain`, etc.). Use the existing `*ApiModel` and its `static from()` factory.
 
 ### JSON column pattern
 
-When a `DataTypes.JSON` column stores a complex object, declare the field with the entity type (e.g. `declare round_state: RoundState`). In `toApiModel()`, cast the field to a `Pick` of the matching contract model to read only the reliably persisted scalar fields — this is safe on plain DB objects without relying on instance methods:
+When a `DataTypes.JSON` column stores a complex object, declare the field with the entity type (e.g. `declare round_state: RoundState`). In `toApiModel()`, convert it via `static from()` on the matching contract model — the factory handles the plain-object-to-instance conversion:
 
 ```typescript
-const rs = this.round_state as Pick<RoundStateApiModel, 'round' | 'duel' | 'team_won' | 'finished' | 'previous_duel'>
+return new GameLogApiModel(
+  RoundStateApiModel.from(this.round_state),
+  ...
+)
 ```
 
 ## Code Rules
 
-> **Never use `any`, `unknown`, or `never` as a type in this codebase.** Use the correct domain type or a named type alias. If a value genuinely has an uncertain shape at runtime (e.g. a JSON column), use `Pick<*ApiModel, ...>` or a proper named interface.
+> **Never use `any`, `unknown`, or `never` as a type in this codebase.** Use the correct domain type or a named type alias. For plain objects from JSON columns or tsoa bodies, use `static from()` on the matching `*ApiModel`.
 
 > **Never use `Object.assign` or `Object.create` to hydrate API models.** Use the constructor directly.
 
 > **Always use `pnpm` scripts — never invoke `docker` or `docker compose` commands directly.** All Docker lifecycle operations are wrapped by pnpm scripts. Examples: `pnpm localdb dev`, `pnpm localdb down`, `pnpm test`, `pnpm dev:docker:up`, `pnpm dev:docker:down`.
 
+> **Every exported function and method must have a JSDoc comment.** Include at minimum a one-line description; add `@param` / `@returns` for non-obvious signatures.
+
+> **Always use path aliases — never use relative imports.** `api/tsconfig.json` defines `@/*` → `src/*` and `@tests/*` → `tests/*`. All imports in `api/src/` use `@/…` and all imports in `api/tests/` use `@tests/…`.
+
 ## Testing
 
-Tests live in `api/tests/api/` and use **Vitest** against a real Docker PostgreSQL instance. Follow the pattern in `health.test.ts`:
+Tests live in `api/tests/api/` and use **Vitest** against a real Docker PostgreSQL instance.
+
+### GWT structure
+
+Follow the **Given / When / Then** split:
+
+- **GIVEN** — fixture setup lives in `beforeAll` / `afterAll`, calling helpers from `common-*.ts`.
+- **WHEN** — the actual API call being tested, written inline in the `it()` body.
+- **THEN** — assertions written inline in the `it()` body. Complex or reusable assertions can be extracted to a helper; if the helper is used in multiple test files, put it in `common-*.ts`.
 
 ```typescript
 import { apiClient } from '@tests/setup'
+import { givenTeamExists, cleanupTeam } from '@tests/api/common-teams'
 import { describe, it, expect, beforeAll, afterAll } from 'vitest'
 
-describe('...', () => {
-  let fixtureId: number
-  beforeAll(async () => { /* create via API */ })
-  afterAll(async () => { /* delete via API */ })
-  it('...', async () => { expect(...) })
+describe('Teams', () => {
+  let teamId: number
+  beforeAll(async () => { teamId = await givenTeamExists() })  // GIVEN
+  afterAll(async () => { await cleanupTeam(teamId) })
+
+  it('returns the team by id', async () => {
+    const result = await apiClient.teams.getTeam(teamId)       // WHEN
+    expect(result.id).toBe(teamId)                             // THEN
+  })
 })
 ```
+
+### `common-*.ts` files
+
+Shared fixture helpers (`givenXExists`, `cleanupX`, shared constants) live in `api/tests/api/common-*.ts`. Rules:
+
+- Every exported function **must have a JSDoc comment** explaining what it sets up or tears down.
+- Functions are named `givenXExists` / `cleanupX` to make the Given/Then intent clear at the call site.
+- Complex assertion helpers reused across test files also go here.
 
 ## Game Mechanics
 

--- a/api/tests/api/games.test.ts
+++ b/api/tests/api/games.test.ts
@@ -12,9 +12,9 @@ import {
 } from '@tests/generated/api'
 import { apiClient } from '@tests/setup'
 import { describe, expect, it, beforeAll, afterAll } from 'vitest'
-import { givenTeamExists, cleanupTeam } from './common-teams'
-import { givenPlayerExists, cleanupPlayer, TEST_PLAYER_ATTRIBUTES } from './common-players'
-import { givenTournamentExists, cleanupTournament, TEST_TOURNAMENT } from './common-tournaments'
+import { givenTeamExists, cleanupTeam } from '@tests/api/common-teams'
+import { givenPlayerExists, cleanupPlayer, TEST_PLAYER_ATTRIBUTES } from '@tests/api/common-players'
+import { givenTournamentExists, cleanupTournament, TEST_TOURNAMENT } from '@tests/api/common-tournaments'
 
 describe('Tournaments, Matches & Games', () => {
   let team1Id: number

--- a/api/tests/api/players.test.ts
+++ b/api/tests/api/players.test.ts
@@ -7,8 +7,8 @@ import {
 } from '@tests/generated/api'
 import { apiClient } from '@tests/setup'
 import { describe, expect, it, beforeAll, afterAll } from 'vitest'
-import { givenPlayerExists, cleanupPlayer, TEST_PLAYER, TEST_PLAYER_ATTRIBUTES } from './common-players'
-import { givenTeamExists, cleanupTeam } from './common-teams'
+import { givenPlayerExists, cleanupPlayer, TEST_PLAYER, TEST_PLAYER_ATTRIBUTES } from '@tests/api/common-players'
+import { givenTeamExists, cleanupTeam } from '@tests/api/common-teams'
 
 describe('Players', () => {
   let teamId: number

--- a/api/tests/api/teams.test.ts
+++ b/api/tests/api/teams.test.ts
@@ -6,8 +6,8 @@ import {
 } from '@tests/generated/api'
 import { apiClient } from '@tests/setup'
 import { describe, expect, it, beforeAll, afterAll } from 'vitest'
-import { givenTeamExists, cleanupTeam, TEST_TEAM } from './common-teams'
-import { givenPlayerExists, cleanupPlayer } from './common-players'
+import { givenTeamExists, cleanupTeam, TEST_TEAM } from '@tests/api/common-teams'
+import { givenPlayerExists, cleanupPlayer } from '@tests/api/common-players'
 
 describe('Teams', () => {
   let teamId: number

--- a/knip.config.ts
+++ b/knip.config.ts
@@ -14,13 +14,6 @@ const config = {
       ignore: ['./app/components/games/GameDetails.tsx'],
     },
   },
-  ignore: [
-    '**/public/**',
-    '**/dist/**',
-    '**/.next/**',
-    '**/node_modules/**',
-    '**/.turbo/**',
-  ],
 } as const satisfies KnipConfig
 
 export default config


### PR DESCRIPTION
## Summary

- **Relative imports → path aliases**: all `./common-*` imports in test files replaced with `@tests/api/*`, consistent with the `@/` and `@tests/` aliases in `api/tsconfig.json`. Relative imports are now banned by AGENTS.md.
- **knip.config.ts**: removed 5 `ignore` globs (`public`, `dist`, `.next`, `node_modules`, `.turbo`) that knip already excludes by default — eliminates the "Configuration hints" warnings from `knip -c knip.config.ts`.
- **AGENTS.md** additions:
  - Mandate `@/` / `@tests/` path aliases over relative imports
  - Mandate JSDoc on every exported function and method
  - Document the GWT (Given/When/Then) test structure: GIVEN in `beforeAll`/`afterAll` via `common-*.ts` helpers, WHEN and THEN inline in `it()` bodies
  - Fix JSON column pattern and naming rules sections to reference `static from()` instead of the superseded `Pick<>` inline cast

## Test plan

- [ ] `pnpm test` passes (70/70)
- [ ] `pnpm knip` reports no configuration hints
- [ ] `pnpm build` compiles cleanly