### PR TITLE
fix(api): fix background scheduler ordering, worker pool leak, and circuit breaker reset

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -228,6 +228,66 @@ A single duel proceeds as follows:
 - A **match** is BO1, BO3, or BO5 — the team winning the majority of games wins the match.
 - Stats tracked per game log: `kills`, `deaths`, `assists`. KDA = `(kills + assists) / deaths` (0 when deaths = 0). Winrate = `matchesWon / matchesPlayed × 100`.
 
+## Background Match Scheduler
+
+The scheduler automatically plays matches when their scheduled date/time is reached. It runs as a Node.js worker thread, separate from the Express request cycle.
+
+### Architecture
+
+```
+SchedulerService (main thread)
+  └── scheduleMatchesToPlayWorker (worker thread)
+        └── sends create_worker messages → SchedulerService
+              └── MatchWorkerService (main thread)
+                    └── playScheduledMatchWorker (worker thread, one per match)
+                          └── MatchService.playFullMatch(matchId)
+```
+
+### Flow
+
+1. **`SchedulerService.startScheduler()`** — spawns `scheduleMatchesToPlayWorker` and sends it a `START` message.
+2. Every 60 seconds (or 120 s under stress) the scheduler worker calls `MatchService.getMatchesToBePlayed(now)`:
+   - Query: `date <= now AND started = false`, ordered by `date ASC` across all tournaments, limit `MAX_CONCURRENT_MATCHES` (20).
+3. For each fetched match it **marks `started = true`** (to prevent duplicate processing) then sends a `create_worker` message to the parent.
+4. **`MatchWorkerService.createMatchWorker`** (max `MAX_CONCURRENT_MATCHES` concurrent) spawns a `playScheduledMatchWorker` for the match.
+   - If the pool is full **or** spawning fails, `started` is **reverted to `false`** so the match is retried next cycle.
+5. **`playScheduledMatchWorker`** calls `MatchService.playFullMatch(matchId)`, then posts a `MatchCompletedMessage` (`WorkerMessageType.MATCH_COMPLETED`) to the parent with `success: true` or `success: false`.
+   - On `success: false`, `MatchWorkerService` reverts `started = false` so the match is retried.
+   - On worker **crash** (`worker.on('error')`), `MatchWorkerService` also reverts `started = false`.
+   - On `success: true`, the match has `finished = true` and is excluded from all future queries.
+
+### Message protocol
+
+`playScheduledMatchWorker` → `MatchWorkerService` uses a single typed message: `MatchCompletedMessage` (`api/src/models/SchedulerTypes.ts`). There are no ad-hoc string message types in the play worker path.
+
+### Circuit Breaker
+
+After 5 consecutive errors the scheduler worker pauses for 60 s before resuming. This is local to `scheduleMatchesToPlayWorker` and only affects match fetching, not in-flight workers. If the scheduler thread crashes it is automatically restarted after 5 s.
+
+### Configuration (`api/src/models/constants.ts`)
+
+| Constant | Default | Meaning |
+|---|---|---|
+| `MAX_CONCURRENT_MATCHES` | 20 | Max matches fetched per cycle and max simultaneous `playScheduledMatchWorker` threads |
+| `STANDARD_CHECK_INTERVAL` | 60 000 ms | Polling interval under normal conditions |
+| `REDUCED_CHECK_INTERVAL` | 120 000 ms | Polling interval when errors are detected |
+| `CIRCUIT_BREAKER_THRESHOLD` | 5 | Consecutive errors before pausing |
+| `CIRCUIT_BREAKER_RESET_TIME` | 60 000 ms | Pause duration before resuming |
+
+### Relevant files
+
+| File | Role |
+|---|---|
+| `api/src/services/SchedulerService.ts` | Lifecycle management, message routing |
+| `api/src/workers/scheduleMatchesToPlayWorker.ts` | Polling loop, circuit breaker |
+| `api/src/services/MatchWorkerService.ts` | Worker pool, `started` revert on error |
+| `api/src/workers/playScheduledMatchWorker.ts` | Executes a single match |
+| `api/src/services/MatchService.ts` | `getMatchesToBePlayed`, `playFullMatch`, `updateMatchStatus` |
+
+### Enabling the scheduler
+
+Set `START_SCHEDULER=true` in the API environment. See `api/src/index.ts` for the conditional startup.
+
 ## Git / PR Conventions
 
 - **Commit format**: conventional commits with scope — `fix(api): ...`, `perf(ui): ...`, `feat(api): ...`

--- a/api/README.md
+++ b/api/README.md
@@ -76,6 +76,25 @@ A Dockerfile is provided for containerized deployment. You can build the image u
 docker build -t vavalm-api .
 ```
 
+## Background Match Scheduler
+
+The scheduler automatically plays matches when their scheduled date/time is reached. Enable it by setting `START_SCHEDULER=true` in the API environment.
+
+### How it works
+
+1. `SchedulerService` spawns a `scheduleMatchesToPlayWorker` thread on startup.
+2. Every 60 s the worker queries for unstarted matches where `date <= now`, ordered by `date ASC` across all tournaments (up to 20 at a time).
+3. Each match is marked `started = true` immediately to prevent duplicate processing.
+4. A `create_worker` message is sent to the parent thread, which asks `MatchWorkerService` to spawn a `playScheduledMatchWorker` (max `MAX_CONCURRENT_MATCHES` concurrent).
+   - If the pool is full, `started` is reverted to `false` and the match is retried next cycle.
+5. `playScheduledMatchWorker` calls `MatchService.playFullMatch`, then posts a typed `MatchCompletedMessage` (`WorkerMessageType.MATCH_COMPLETED`) to the parent with `success: true/false`.
+   - On `success: false` or an uncaught worker crash, `MatchWorkerService` reverts `started = false` so the match is retried.
+   - On `success: true`, the match has `finished = true` and leaves the query results permanently.
+
+A circuit breaker in `scheduleMatchesToPlayWorker` pauses match fetching for 60 s after 5 consecutive errors. The scheduler thread auto-restarts after crashes (5 s delay).
+
+Configuration constants are in `src/models/constants.ts`.
+
 ## Project Structure
 
 - `/src/base` - Core application components

--- a/api/src/models/SchedulerTypes.ts
+++ b/api/src/models/SchedulerTypes.ts
@@ -22,37 +22,24 @@ export enum WorkerMessageType {
   START = 'start',
   PAUSE = 'pause',
   RESUME = 'resume',
-  DB_ERROR = 'db_error',
   MATCH_COMPLETED = 'match_completed'
 }
 
 /**
- * Error report message interface
- */
-export interface ErrorReportMessage {
-  type: WorkerMessageType.DB_ERROR
-  error: {
-    message: string
-    name: string
-    stack?: string
-  }
-}
-
-/**
- * Match completed message interface
+ * Match completed message interface — sent from playScheduledMatchWorker to MatchWorkerService
  */
 export interface MatchCompletedMessage {
   type: WorkerMessageType.MATCH_COMPLETED
   matchId: number
   success: boolean
+  error?: string
 }
 
 /**
  * Union type for all worker messages
  */
-export type WorkerMessage = 
+export type WorkerMessage =
   | WorkerMessageType.START
   | WorkerMessageType.PAUSE
   | WorkerMessageType.RESUME
-  | ErrorReportMessage
-  | MatchCompletedMessage 
+  | MatchCompletedMessage

--- a/api/src/models/constants.ts
+++ b/api/src/models/constants.ts
@@ -1,9 +1,8 @@
 // Worker configuration
-export const MAX_CONCURRENT_MATCHES = 10
-export const MAX_CONCURRENT_WORKERS = 4
+export const MAX_CONCURRENT_MATCHES = 20
 
 // Scheduler configuration
 export const STANDARD_CHECK_INTERVAL = 60000 // 1 minute between checks
 export const REDUCED_CHECK_INTERVAL = 120000 // 2 minutes when under stress
 export const CIRCUIT_BREAKER_THRESHOLD = 5 // Number of consecutive errors before circuit breaks
-export const CIRCUIT_BREAKER_RESET_TIME = 60000 // 1 minute until circuit resets 
+export const CIRCUIT_BREAKER_RESET_TIME = 60000 // 1 minute until circuit resets

--- a/api/src/services/MatchService.ts
+++ b/api/src/services/MatchService.ts
@@ -27,6 +27,7 @@ const MatchService = {
     // Get count of all matches from tournament, then get the matches with limit and offset
     const tournamentMatches = await Match.findAndCountAll({
       where: { tournament_id: tournamentId },
+      order: [['date', 'ASC'], ['id', 'ASC']],
       limit,
       offset,
     })
@@ -131,21 +132,19 @@ const MatchService = {
   },
 
   /**
-   * Retrieves all matches that should be played based on a before date.
-   * It limits the number of matches to 10 at at time.
-   * 
-   * @param {Date} before - A date that represents the maximum date for the matches to be played.
-   * @returns {Promise<Match[]>} A promise that resolves to an array of games that should be played.
+   * Retrieves the next batch of unstarted matches up to MAX_CONCURRENT_MATCHES,
+   * ordered by date ascending across all tournaments.
+   *
+   * @param {Date} before - Upper bound for the match date (inclusive).
+   * @returns {Promise<Match[]>} Matches to play next.
    */
   getMatchesToBePlayed: async (before: Date): Promise<Match[]> => {
     return await Match.findAll({
       where: {
-        date: {
-          [Op.lte]: before,
-        },
+        date: { [Op.lte]: before },
         started: false,
       },
-      order: [['date', 'ASC']],
+      order: [['date', 'ASC'], ['id', 'ASC']],
       limit: MAX_CONCURRENT_MATCHES,
     })
   },

--- a/api/src/services/MatchWorkerService.ts
+++ b/api/src/services/MatchWorkerService.ts
@@ -1,6 +1,7 @@
 import { Worker } from 'worker_threads'
-import { WorkerStatus } from '@/models/SchedulerTypes'
-import { MAX_CONCURRENT_WORKERS } from '@/models/constants'
+import MatchService from '@/services/MatchService'
+import { WorkerStatus, WorkerMessageType, MatchCompletedMessage } from '@/models/SchedulerTypes'
+import { MAX_CONCURRENT_MATCHES } from '@/models/constants'
 
 // Track active workers to manage resources
 let workerPool: Worker[] = []
@@ -73,8 +74,8 @@ const createMatchWorker = async (matchId: number, matchData: unknown): Promise<b
     return false
   }
   
-  if (workerPool.length >= MAX_CONCURRENT_WORKERS) {
-    console.log(`Worker pool at capacity (${MAX_CONCURRENT_WORKERS}), delaying match ${matchId} processing`)
+  if (workerPool.length >= MAX_CONCURRENT_MATCHES) {
+    console.log(`Worker pool at capacity (${MAX_CONCURRENT_MATCHES}), delaying match ${matchId} processing`)
     return false
   }
   
@@ -94,14 +95,38 @@ const createMatchWorker = async (matchId: number, matchData: unknown): Promise<b
       workerData: { matchToPlay: workerData },
     })
     
+    // Tracks whether the worker reported completion normally (via message or error event).
+    // Used to avoid a false-positive revert when worker.terminate() causes a non-zero exit code.
+    let completionHandled = false
+
     worker.on('error', (error) => {
       console.error(`Worker error for match ${extractedId}:`, error)
-      removeWorker(worker)
+      completionHandled = true
+      MatchService.updateMatchStatus(extractedId, { started: false })
+        .catch(e => console.error(`Failed to revert started for match ${extractedId} after crash:`, e))
     })
-    
+
     worker.on('exit', (code) => {
       removeWorker(worker)
-      console.log(`Worker for match ${extractedId} completed with code ${code}`)
+      if (!completionHandled) {
+        console.error(`Worker for match ${extractedId} exited unexpectedly (code ${code}), reverting started status`)
+        MatchService.updateMatchStatus(extractedId, { started: false })
+          .catch(e => console.error(`Failed to revert started for match ${extractedId}:`, e))
+      } else {
+        console.log(`Worker for match ${extractedId} exited (code ${code})`)
+      }
+    })
+
+    worker.on('message', (message: MatchCompletedMessage) => {
+      if (message?.type !== WorkerMessageType.MATCH_COMPLETED) return
+      completionHandled = true
+      if (!message.success) {
+        console.log(`Match ${message.matchId} failed, reverting started status for retry`)
+        MatchService.updateMatchStatus(message.matchId, { started: false })
+          .catch(e => console.error(`Failed to revert started for match ${message.matchId}:`, e))
+      }
+      // Terminate the worker — Sequelize pool timers keep its event loop alive otherwise
+      worker.terminate()
     })
     
     // Add to pool and return success
@@ -162,7 +187,7 @@ const cleanup = (): void => {
 const getWorkerPoolStatus = (): Pick<WorkerStatus, 'activeWorkers' | 'maxWorkers' | 'paused'> => {
   return {
     activeWorkers: workerPool.length,
-    maxWorkers: MAX_CONCURRENT_WORKERS,
+    maxWorkers: MAX_CONCURRENT_MATCHES,
     paused: schedulerPaused,
   }
 }

--- a/api/src/services/SchedulerService.ts
+++ b/api/src/services/SchedulerService.ts
@@ -1,5 +1,6 @@
 import { Worker } from 'worker_threads'
 import MatchWorkerService from '@/services/MatchWorkerService'
+import MatchService from '@/services/MatchService'
 import { WorkerStatus, WorkerMessageType } from '@/models/SchedulerTypes'
 
 // Track scheduler state
@@ -47,8 +48,8 @@ const startScheduler = (): void => {
         MatchWorkerService.createMatchWorker(matchId, { id: matchId })
           .then(success => {
             if (!success) {
-              console.log(`Failed to create worker for match ${matchId}, notifying worker`)
-              // Notify worker of failure if needed
+              console.log(`Failed to create worker for match ${matchId}, reverting started status`)
+              return MatchService.updateMatchStatus(matchId, { started: false })
             }
           })
           .catch(error => {

--- a/api/src/workers/playScheduledMatchWorker.ts
+++ b/api/src/workers/playScheduledMatchWorker.ts
@@ -1,137 +1,41 @@
 import { parentPort, workerData } from 'worker_threads'
 import MatchService from '@/services/MatchService'
-
-// Define possible worker data formats to handle various input types
-interface WorkerMatchData {
-  matchId?: number;
-  id?: number;
-  dataValues?: {
-    id?: number;
-  };
-}
+import { WorkerMessageType, MatchCompletedMessage } from '@/models/SchedulerTypes'
 
 interface WorkerData {
-  matchToPlay: WorkerMatchData;
+  matchToPlay: { matchId: number }
 }
 
 const { matchToPlay } = workerData as WorkerData
 
-// Debug the received match data
-console.log('Worker received match data:', JSON.stringify(matchToPlay, null, 2))
-
 /**
- * Reports database errors back to the parent thread
- */
-const reportDbError = (error: Error): void => {
-  // Check if this is a database-related error
-  const errorString = String(error)
-  if (
-    errorString.includes('database') || 
-    errorString.includes('timeout') || 
-    errorString.includes('sequelize') ||
-    errorString.includes('connection') ||
-    errorString.includes('ECONNREFUSED') ||
-    errorString.includes('too many clients')
-  ) {
-    console.error('Database error detected in worker, notifying parent')
-    if (parentPort) {
-      parentPort.postMessage({
-        type: 'db_error',
-        error: {
-          message: error.message || 'Unknown database error',
-          name: error.name || 'Error',
-          stack: error.stack,
-        },
-      })
-    }
-  }
-}
-
-/**
- * Safely gets the match ID from the worker data
- */
-const getMatchId = (): number | undefined => {
-  if (!matchToPlay) return undefined
-  
-  // Try to get ID from the minimal object format we're now using
-  if (matchToPlay.matchId) return matchToPlay.matchId
-  
-  // Fallbacks for compatibility with old format
-  if (typeof matchToPlay.id !== 'undefined') return matchToPlay.id
-  
-  // If we still have a nested structure
-  if (matchToPlay.dataValues && typeof matchToPlay.dataValues.id !== 'undefined') {
-    return matchToPlay.dataValues.id
-  }
-  
-  return undefined
-}
-
-/**
- * Starts the execution of a match.
- * 
- * @returns void
+ * Executes the match and notifies the parent thread with a MatchCompletedMessage.
  */
 const startMatchExecution = async (): Promise<void> => {
+  const matchId = matchToPlay?.matchId
+
+  if (!matchId) {
+    throw new Error('Could not determine match ID from worker data')
+  }
+
   try {
-    console.log('Starting match execution with data:', matchToPlay)
-
-    // Get the match ID from the data
-    const matchId = getMatchId()
-    
-    if (!matchId) {
-      throw new Error('Could not determine match ID from worker data')
-    }
-
     console.log(`Playing match ${matchId}`)
-    // Use the MatchService to execute the match
     await MatchService.playFullMatch(matchId)
-    console.log(`Match ${matchId} has been played`)
-    
-    // Signal success to parent
-    if (parentPort) {
-      parentPort.postMessage({
-        type: 'success',
-        matchId,
-      })
-    }
+    console.log(`Match ${matchId} completed successfully`)
+
+    const message: MatchCompletedMessage = { type: WorkerMessageType.MATCH_COMPLETED, matchId, success: true }
+    parentPort?.postMessage(message)
   } catch (error) {
-    // Get match ID safely for error reporting
-    const matchId = getMatchId()
-    console.error(`Error playing match ${matchId || 'unknown'}:`, error)
-    
-    // Report database errors for circuit breaker
-    reportDbError(error instanceof Error ? error : new Error(String(error)))
-    
-    // Signal error to parent
-    if (parentPort) {
-      parentPort.postMessage({
-        type: 'error',
-        matchId: matchId || 'unknown',
-        error: String(error),
-      })
+    console.error(`Error playing match ${matchId}:`, error)
+
+    const message: MatchCompletedMessage = {
+      type: WorkerMessageType.MATCH_COMPLETED,
+      matchId,
+      success: false,
+      error: String(error),
     }
+    parentPort?.postMessage(message)
   }
 }
 
-// Start the match execution and notify the parent thread when done
 startMatchExecution()
-  .catch(error => {
-    // Get match ID safely for error reporting
-    const matchId = getMatchId()
-    console.error(`Unhandled error in match execution for match ${matchId || 'unknown'}:`, error)
-    reportDbError(error instanceof Error ? error : new Error(String(error)))
-  })
-  .finally(() => {
-    // Force exit the worker to ensure no lingering connections
-    // This is a sledgehammer approach but guarantees connection release
-    const matchId = getMatchId()
-    setTimeout(() => {
-      console.log(`Worker for match ${matchId || 'unknown'} is shutting down to free connections`)
-      if (parentPort) {
-        parentPort.postMessage({ type: 'shutdown' })
-      } else {
-        throw new Error('Worker shutdown: Parent port not available')
-      }
-    }, 500)
-  })

--- a/api/src/workers/scheduleMatchesToPlayWorker.ts
+++ b/api/src/workers/scheduleMatchesToPlayWorker.ts
@@ -1,9 +1,8 @@
 import { parentPort } from 'worker_threads'
 import Match from '@/models/Match'
 import MatchService from '@/services/MatchService'
-import { WorkerMessageType, ErrorReportMessage } from '@/models/SchedulerTypes'
+import { WorkerMessageType } from '@/models/SchedulerTypes'
 import {
-  MAX_CONCURRENT_MATCHES,
   STANDARD_CHECK_INTERVAL,
   REDUCED_CHECK_INTERVAL,
   CIRCUIT_BREAKER_THRESHOLD,
@@ -19,43 +18,15 @@ let circuitBroken = false
 let lastCircuitBreak = 0
 
 /**
- * Reports a database error back to the parent thread
- * 
- * @param error The error that occurred
- */
-const reportDbError = (error: Error): void => {
-  if (parentPort) {
-    try {
-      const errorMessage: ErrorReportMessage = {
-        type: WorkerMessageType.DB_ERROR,
-        error: {
-          message: error.message,
-          name: error.name,
-          stack: error.stack,
-        },
-      }
-      parentPort.postMessage(errorMessage)
-    } catch (e) {
-      console.error('Failed to report error to parent:', e)
-    }
-  }
-}
-
-/**
- * Handles database errors and implements circuit breaker pattern
- * 
+ * Handles errors and implements circuit breaker pattern
+ *
  * @param error The error that occurred
  */
 const handleDbError = (error: Error): void => {
-  console.error('Database error in scheduler worker:', error)
+  console.error('Error in scheduler worker:', error)
 
-  // Track consecutive errors for circuit breaker
   consecutiveErrors++
 
-  // Report error to parent process
-  reportDbError(error)
-
-  // Implement circuit breaker pattern
   if (consecutiveErrors >= CIRCUIT_BREAKER_THRESHOLD) {
     circuitBroken = true
     lastCircuitBreak = Date.now()
@@ -88,26 +59,21 @@ const recordSuccess = (): void => {
  * Fetch matches that should be played based on their scheduled time
  */
 const fetchMatchesThatShouldBePlayed = async (): Promise<Match[]> => {
-  // Skip processing if circuit breaker is active or worker is paused
+  resetCircuitBreakerIfNeeded()
+
   if (circuitBroken || workerPaused) {
     return []
   }
 
   try {
-    // Reset circuit breaker if needed
-    resetCircuitBreakerIfNeeded()
 
     const now = new Date()
-    // Get matches that should be played using MatchService
     const matchesToPlay = await MatchService.getMatchesToBePlayed(now)
-
-    // Limit to prevent overloading the system
-    const limitedMatches = matchesToPlay.slice(0, MAX_CONCURRENT_MATCHES)
 
     // Record success for circuit breaker
     recordSuccess()
 
-    return limitedMatches as Match[]
+    return matchesToPlay as Match[]
   } catch (error) {
     handleDbError(error as Error)
     return []


### PR DESCRIPTION
Several bugs were preventing the background match scheduler from working correctly:

**Worker pool stuck at capacity**: Sequelize's `pool.min: 2` + 1 s eviction `setInterval` kept each `playScheduledMatchWorker` event loop alive indefinitely, so `worker.on('exit')` never fired and workers were never removed from the pool. Fixed by having the parent call `worker.terminate()` after receiving `MATCH_COMPLETED`. A `completionHandled` flag prevents the forced-terminate non-zero exit code from triggering a false-positive `started = false` revert.

**Matches permanently stuck as `started = true`**: When `createMatchWorker` returned false (pool full or spawn error), `SchedulerService` only logged — it never reverted `started`. Those matches were excluded from all future scheduler queries. Fixed by calling `MatchService.updateMatchStatus(matchId, { started: false })` on failure.

**Circuit breaker never recovering**: `resetCircuitBreakerIfNeeded()` was called inside the `if (circuitBroken) return []` guard, making it unreachable when the breaker was open. After 5 errors the scheduler would pause forever. Fixed by moving the reset call before the guard.

**Match ordering non-deterministic**: `getMatchesToBePlayed` had no stable sort. Added `ORDER BY date ASC, id ASC` (flat across all tournaments) so earlier-scheduled matches always process first. Same fix applied to `getMatchesFromTournament` for stable pagination.

**Other cleanup**: simplified `playScheduledMatchWorker` (removed dead code, unified to typed `MatchCompletedMessage`); removed `MAX_CONCURRENT_WORKERS` constant; bumped `MAX_CONCURRENT_MATCHES` to 20; added scheduler architecture docs to `AGENTS.md` and `api/README.md`.