### PR TITLE
fix(api): credit player results to the team they played for

### DIFF
--- a/api/src/services/PlayerService.ts
+++ b/api/src/services/PlayerService.ts
@@ -48,11 +48,26 @@ export const updateOrCreatePlayer = async (playerData: VlrPlayer, team: Team): P
 }
 
 /**
- * Updates or creates a player based on the player data and team.
- * @param playerData player data from VLR
- * @param team team data saved in the database
- * @returns {Promise<Player>} - The player created or updated.
- * 
+ * Returns the game stats row a player's per-game record belongs to, whichever
+ * side they played on.
+ * @param stats the player's stats row for a single game
+ */
+const gameStatsForPlayer = (stats: PlayerGameStats): GameStats | undefined =>
+  stats.game_stats_player1 ?? stats.game_stats_player2
+
+/**
+ * Returns the id of the team the player actually played for in that game,
+ * taken from the side they were recorded on rather than their current team.
+ * @param stats the player's stats row for a single game
+ */
+const teamIdForGame = (stats: PlayerGameStats): number | undefined =>
+  stats.game_stats_player1?.team1_id ?? stats.game_stats_player2?.team2_id
+
+/**
+ * Aggregates every recorded game into a single stats summary for one player.
+ * @param playerId the player to summarise
+ * @returns {Promise<AllPlayerStats>} - The player's aggregated statistics.
+ *
 **/
 export const getAllStatsForPlayer = async (playerId: number): Promise<AllPlayerStats> => {
   const playerStats = await PlayerGameStats.findAll({
@@ -112,35 +127,37 @@ export const getAllStatsForPlayer = async (playerId: number): Promise<AllPlayerS
     )
   }
 
-  // Get all maps the specific player has won and played
-  const totalMapWins = playerStats.reduce((acc, stats) => {
-    if (stats.player.team_id === stats.game_stats_player1?.winner_id || stats.player.team_id === stats.game_stats_player2?.winner_id) {
-      return acc + 1
-    }
-    return acc
-  }
-  , 0)
+  // Which side a player took is recorded per game: a row linked through
+  // game_stats_player1 was played for that game's team1, one linked through
+  // game_stats_player2 for its team2. Reading the side rather than the player's
+  // current team_id keeps historical stats correct after a transfer.
+  const totalMapWins = playerStats.filter(stats => {
+    const teamId = teamIdForGame(stats)
+    return teamId !== undefined && gameStatsForPlayer(stats)?.winner_id === teamId
+  }).length
   const totalMaps = playerStats.length
 
-  // Get all Matches then filter by distinct matches
-  // Compare with the team_id of the player at the time of the match
-  const distinctMatches = playerStats
-    .map(stats => stats.game_stats_player1?.game.match || stats.game_stats_player2?.game.match)
-    .filter((match, index, self) => match && index === self.findIndex(t => t?.id === match.id))
-  const totalMatchesWon = distinctMatches.reduce((acc, match) => {
-    if (match && playerStats.some(stats => stats.player.team_id === match.winner_id)) {
-      return acc + 1
+  // A match spans several games, so collapse to distinct matches, remembering
+  // the side the player took in each one.
+  const matchesPlayed = new Map<number, { match: Match, teamId: number }>()
+  for (const stats of playerStats) {
+    const match = gameStatsForPlayer(stats)?.game?.match
+    const matchId = match?.id
+    const teamId = teamIdForGame(stats)
+    if (match && matchId !== undefined && teamId !== undefined && !matchesPlayed.has(matchId)) {
+      matchesPlayed.set(matchId, { match, teamId })
     }
-    return acc
   }
-  , 0)
+  const totalMatchesPlayed = matchesPlayed.size
+  const totalMatchesWon = Array.from(matchesPlayed.values())
+    .filter(({ match, teamId }) => match.winner_id === teamId).length
 
   const totalKills = playerStats.reduce((acc, stats) => acc + stats.kills, 0)
   const totalDeaths = playerStats.reduce((acc, stats) => acc + stats.deaths, 0)
   const totalAssists = playerStats.reduce((acc, stats) => acc + stats.assists, 0)
   const kda = totalDeaths === 0 ? 0 : parseFloat(((totalKills + totalAssists) / totalDeaths).toFixed(2))
 
-  const winrate = parseFloat(((totalMatchesWon / distinctMatches.length) * 100).toFixed(2))
+  const winrate = parseFloat(((totalMatchesWon / totalMatchesPlayed) * 100).toFixed(2))
   const mapWinrate = parseFloat(((totalMapWins / totalMaps) * 100).toFixed(2))
 
   return new AllPlayerStats(
@@ -148,9 +165,9 @@ export const getAllStatsForPlayer = async (playerId: number): Promise<AllPlayerS
     kda,
     winrate,
     mapWinrate,
-    distinctMatches.length,               // totalMatchesPlayed
+    totalMatchesPlayed,                    // totalMatchesPlayed
     totalMatchesWon,                       // totalMatchesWon
-    distinctMatches.length - totalMatchesWon, // totalMatchesLost
+    totalMatchesPlayed - totalMatchesWon,  // totalMatchesLost
     totalMaps,                            // totalMapsPlayed
     totalMapWins,                         // totalMapsWon
     totalMaps - totalMapWins,             // totalMapsLost

--- a/api/tests/api/player-match-attribution.test.ts
+++ b/api/tests/api/player-match-attribution.test.ts
@@ -1,0 +1,77 @@
+import { AllPlayerStats, PlayerApiModel, TeamStats } from '@tests/generated/api'
+import { apiClient } from '@tests/setup'
+import { describe, expect, it, beforeAll, afterAll } from 'vitest'
+import { givenPlayedMatchExists, cleanupPlayedMatch, getPlayedMatch, PlayedMatchFixture } from '@tests/api/common-stats'
+
+describe('Player match win attribution', () => {
+  let fixture: PlayedMatchFixture
+  let winnerTeamId: number | undefined
+  let winningPlayerId: number
+  let losingPlayerId: number
+
+  beforeAll(async () => {
+    fixture = await givenPlayedMatchExists('PMA')
+    const match = await getPlayedMatch(fixture.matchId)
+    winnerTeamId = match.winner_id
+
+    const team1Won = winnerTeamId === fixture.team1Id
+    winningPlayerId = team1Won ? fixture.team1PlayerIds[0] : fixture.team2PlayerIds[0]
+    losingPlayerId = team1Won ? fixture.team2PlayerIds[0] : fixture.team1PlayerIds[0]
+  }, 120_000)
+
+  afterAll(async () => {
+    await cleanupPlayedMatch(fixture)
+  }, 60_000)
+
+  it('produces a decided match', () => {
+    expect(winnerTeamId).toBeTruthy()
+    expect([fixture.team1Id, fixture.team2Id]).toContain(winnerTeamId)
+  })
+
+  it('credits the win only to players on the winning team', async () => {
+    const winner = await apiClient.default.getPlayerStats(winningPlayerId) as AllPlayerStats
+    const loser = await apiClient.default.getPlayerStats(losingPlayerId) as AllPlayerStats
+
+    expect(winner.totalMatchesPlayed).toBe(1)
+    expect(winner.totalMatchesWon).toBe(1)
+    expect(winner.totalMatchesLost).toBe(0)
+
+    expect(loser.totalMatchesPlayed).toBe(1)
+    expect(loser.totalMatchesWon).toBe(0)
+    expect(loser.totalMatchesLost).toBe(1)
+  })
+
+  it('agrees with the team stats for the same match', async () => {
+    const teamStats = await apiClient.default.getTeamStats(winnerTeamId!) as TeamStats
+    const playerStats = await apiClient.default.getPlayerStats(winningPlayerId) as AllPlayerStats
+
+    expect(playerStats.totalMatchesWon).toBe(teamStats.totalMatchesWon)
+    expect(playerStats.totalMapsWon).toBe(teamStats.totalMapsWon)
+    expect(playerStats.totalMapsPlayed).toBe(teamStats.totalMapsPlayed)
+  })
+
+  it('keeps historical results with the team the player actually played for after a transfer', async () => {
+    const before = await apiClient.default.getPlayerStats(winningPlayerId) as AllPlayerStats
+    const player = await apiClient.default.getPlayer(winningPlayerId) as PlayerApiModel
+    const otherTeamId = winnerTeamId === fixture.team1Id ? fixture.team2Id : fixture.team1Id
+
+    // WHEN the player transfers to the team they beat
+    await apiClient.default.updatePlayer(winningPlayerId, { ...player, team_id: otherTeamId })
+
+    try {
+      const after = await apiClient.default.getPlayerStats(winningPlayerId) as AllPlayerStats
+
+      // THEN the already-played match is still recorded as a win, because the
+      // side they played on is stored per game rather than read from the
+      // player's current team.
+      expect(after.totalMatchesWon).toBe(before.totalMatchesWon)
+      expect(after.totalMatchesLost).toBe(before.totalMatchesLost)
+      expect(after.totalMapsWon).toBe(before.totalMapsWon)
+      expect(after.totalMapsLost).toBe(before.totalMapsLost)
+      expect(after.winrate).toBe(before.winrate)
+      expect(after.mapWinrate).toBe(before.mapWinrate)
+    } finally {
+      await apiClient.default.updatePlayer(winningPlayerId, { ...player, team_id: winnerTeamId! })
+    }
+  })
+})


### PR DESCRIPTION
> Stacked on #218 — review that one first. This PR's diff against `main` includes it.

## Why

`getAllStatsForPlayer` decided whether a match counted as a win like this:

```ts
if (match && playerStats.some(stats => stats.player.team_id === match.winner_id))
```

`stats.player` is the same player on every row, so this reduces to *"is the match winner the player's **current** team?"* — which is wrong the moment a player transfers. Their entire history gets rewritten: every win earned with the old team silently becomes a loss, and wins their new team earned before they joined get credited to them. The comment two lines above even states the intended behaviour — *"Compare with the team_id of the player at the time of the match"* — it just was not what the code did.

It is also needlessly quadratic: `playerStats.some(...)` rescans every stats row once per distinct match.

## What changed

The side a player took is already recorded per game — a `PlayerGameStats` row linked through `game_stats_player1` belongs to that game's `team1_id`, one linked through `game_stats_player2` to its `team2_id`. Reading that instead of `player.team_id`:

- fixes attribution across transfers, for both match wins and map wins;
- collapses the per-match rescan into one pass over the rows (`O(M×S)` → `O(M+S)`).

`totalMapWins` had the same flaw and is fixed the same way. Two small documented helpers (`gameStatsForPlayer`, `teamIdForGame`) keep the side-reading logic in one place.

## Verification

The new transfer test fails on the old logic with exactly the described defect — a player's win becomes a loss once they move to the team they beat:

```
AssertionError: expected +0 to be 1
```

It passes with the fix. Also asserts the win is credited only to the winning side, and that a player's totals agree with their team's own stats for the same match. Full `api` suite green locally (84 tests) against a real Postgres.
