### PR TITLE
ci: cancel a branch's in-flight run when it is pushed again

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,6 +9,12 @@ on:
 permissions:
   contents: read
 
+# One run per branch: pushing again cancels the run still in flight, since its
+# result is already out of date.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Why

Pushing again to a branch supersedes whatever is still running for that ref, so the older run keeps a runner busy producing a result nobody will read. During this stats work it was routine to have two runs going on the same branch, with only the newer one meaningful.

## What changed

```yaml
concurrency:
  group: ${{ github.workflow }}-${{ github.ref }}
  cancel-in-progress: true
```

One run per branch. Grouping on `github.ref` keeps branches independent of each other.

## Verification

Workflow parses with the concurrency group intact and the `build` job and its 10 steps unchanged. It applies to `main` too, as requested.