### PR TITLE
perf(api): stop every match worker opening a full connection pool

### DIFF
--- a/api/src/models/constants.ts
+++ b/api/src/models/constants.ts
@@ -1,6 +1,14 @@
 // Worker configuration
 export const MAX_CONCURRENT_MATCHES = 20
 
+// A match worker plays one match at a time, so it needs a couple of
+// connections rather than a full request-serving pool. Every worker thread
+// gets its own Sequelize instance, so the configured pool size would otherwise
+// be multiplied by MAX_CONCURRENT_MATCHES against the database's connection
+// limit — 20 workers at 20 connections each is 400, well past postgres's
+// default max_connections of 100.
+export const MATCH_WORKER_POOL_MAX = 2
+
 // Scheduler configuration
 export const STANDARD_CHECK_INTERVAL = 60000 // 1 minute between checks
 export const REDUCED_CHECK_INTERVAL = 120000 // 2 minutes when under stress

--- a/api/src/models/db.ts
+++ b/api/src/models/db.ts
@@ -1,9 +1,32 @@
 import { Sequelize, Dialect } from 'sequelize'
+import { isMainThread } from 'worker_threads'
 import config from '@/config/config.json'
+import { MATCH_WORKER_POOL_MAX } from '@/models/constants'
 
 type Environment = 'development' | 'test' | 'production'
 const env = (process.env.NODE_ENV || 'development') as Environment
 const dbConfig = config[env]
+
+/**
+ * Connection pool bounds for the thread this module was loaded in.
+ *
+ * Worker threads get their own module instance, so they each build their own
+ * pool. The main thread serves every request and keeps the configured size; a
+ * match worker plays one match and takes a small pool with no idle minimum, so
+ * the total stays well inside the database's connection limit.
+ *
+ * @param onMainThread - Whether this is the main thread rather than a worker.
+ * @returns The max and min connections this thread should hold.
+ */
+export const resolvePoolBounds = (onMainThread: boolean): { max: number, min: number } => {
+  if (onMainThread) {
+    return { max: dbConfig.pool.max, min: dbConfig.pool.min }
+  }
+
+  return { max: Math.min(MATCH_WORKER_POOL_MAX, dbConfig.pool.max), min: 0 }
+}
+
+const poolBounds = resolvePoolBounds(isMainThread)
 
 const sequelize = new Sequelize(
   dbConfig.database,
@@ -13,8 +36,8 @@ const sequelize = new Sequelize(
     host: dbConfig.host,
     dialect: dbConfig.dialect as Dialect,
     pool: {
-      max: dbConfig.pool.max,
-      min: dbConfig.pool.min,
+      max: poolBounds.max,
+      min: poolBounds.min,
       acquire: dbConfig.pool.acquire,
       idle: dbConfig.pool.idle,
       evict: dbConfig.pool.evict,

--- a/api/tests/unit/db-pool.test.ts
+++ b/api/tests/unit/db-pool.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest'
+import { resolvePoolBounds } from '@/models/db'
+import { MATCH_WORKER_POOL_MAX, MAX_CONCURRENT_MATCHES } from '@/models/constants'
+import config from '@/config/config.json'
+
+/** Postgres ships with this many connection slots by default. */
+const DEFAULT_POSTGRES_MAX_CONNECTIONS = 100
+
+describe('Database connection pool sizing', () => {
+  const configured = config.production.pool
+
+  it('gives the main thread the configured pool', () => {
+    const bounds = resolvePoolBounds(true)
+
+    expect(bounds.max).toBe(configured.max)
+    expect(bounds.min).toBe(configured.min)
+  })
+
+  it('gives a match worker a small pool', () => {
+    const bounds = resolvePoolBounds(false)
+
+    expect(bounds.max).toBe(MATCH_WORKER_POOL_MAX)
+    expect(bounds.max).toBeLessThan(configured.max)
+  })
+
+  it('holds no idle connections open in a match worker', () => {
+    // Workers come and go with matches, so an idle minimum in each of them is
+    // just connections parked away from the thread serving requests.
+    expect(resolvePoolBounds(false).min).toBe(0)
+  })
+
+  it('never asks a worker for more than the configured maximum', () => {
+    expect(resolvePoolBounds(false).max).toBeLessThanOrEqual(configured.max)
+  })
+
+  it('keeps every thread combined inside the default postgres limit', () => {
+    // One main thread plus MAX_CONCURRENT_MATCHES workers, each with its own
+    // Sequelize instance and therefore its own pool.
+    const worstCase = resolvePoolBounds(true).max + MAX_CONCURRENT_MATCHES * resolvePoolBounds(false).max
+
+    expect(worstCase).toBeLessThan(DEFAULT_POSTGRES_MAX_CONNECTIONS)
+  })
+})


### PR DESCRIPTION
## Why

Match simulation runs in worker threads, and a worker thread gets its own module registry — so each `playScheduledMatchWorker` re-imports `models/db` and builds **its own** Sequelize pool.

That pool is sized for the thread serving HTTP requests:

```json
"pool": { "max": 20, "min": 2, ... }
```

With `MAX_CONCURRENT_MATCHES = 20`, that is 21 independent pools — up to **420 connections** against postgres's default `max_connections` of **100**, and `min: 2` means 40 are opened eagerly before a single match is played.

This is the mechanism behind the original report that stats got slow *after games were executed*: requests were queueing behind match simulation for connections.

## What changed

`resolvePoolBounds` sizes the pool for the thread it is loaded in. The main thread keeps the configured pool. A worker plays one match at a time, so it takes at most `MATCH_WORKER_POOL_MAX` (2) and holds no idle minimum — workers come and go with matches, so an idle floor in each of them is just connections parked away from the thread serving requests.

| | Before | After |
|---|---|---|
| Worst-case connections | ~420 | **60** |
| Held open at idle | 40 | **0** |

The worker cap is also clamped to the configured max, so lowering `pool.max` below 2 still holds.

## Verification

Five unit tests in `tests/unit/db-pool.test.ts` cover main-thread sizing, worker sizing, the zero idle minimum, the clamp, and the combined worst case staying inside postgres's default limit. Full `api` suite green (99 tests), lint clean.

Note this only changes pool *sizing*; nothing about how workers are spawned or how matches are played.