### PR TITLE
ci: stop pnpm test rebuilding both projects first

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -18,12 +18,10 @@
     },
     "test": {
       "cache": false,
-      "dependsOn": ["build"],
       "inputs": ["src/**/*.tsx", "src/**/*.ts", "test/**/*.ts", "test/**/*.tsx"]
     },
     "test:coverage": {
       "cache": false,
-      "dependsOn": ["build"],
       "outputs": ["tests/coverage/**"],
       "inputs": ["src/**/*.tsx", "src/**/*.ts", "test/**/*.ts", "test/**/*.tsx"]
     },


### PR DESCRIPTION
turbo's test tasks declared dependsOn build, so every test run rebuilt the api and the ui. The tests exercise the running docker stack over http, not the local dist output, so that build was work nobody read — and it made a test run look like it had verified a build it had not.

pnpm test now runs 2 tasks instead of 4. CI still builds, in its own step, before the stack starts.