### PR TITLE
fix(ui): load team logos from API host

### DIFF
--- a/api/docs/openapi.yaml
+++ b/api/docs/openapi.yaml
@@ -1333,8 +1333,7 @@ paths:
                 type: string
                 format: byte
       description: Downloads a team's logo image.
-      security:
-        - BearerAuth: []
+      security: []
       parameters:
         - description: The team whose logo to download
           in: path

--- a/api/src/base/FileUtils.ts
+++ b/api/src/base/FileUtils.ts
@@ -17,3 +17,23 @@ export const downloadPNGImage = async (url: string): Promise<Buffer | null> => {
     return null
   }
 }
+
+export type ImageMimeType = 'image/gif' | 'image/jpeg' | 'image/png' | 'image/webp'
+
+/**
+ * Detects the MIME type of stored image bytes.
+ * @param image image bytes to inspect
+ * @returns MIME type suitable for an HTTP Content-Type header
+ */
+export const detectImageMimeType = (image: Buffer): ImageMimeType => {
+  if (image.subarray(0, 3).equals(Buffer.from([0xff, 0xd8, 0xff]))) {
+    return 'image/jpeg'
+  }
+  if (image.subarray(0, 6).toString('ascii') === 'GIF87a' || image.subarray(0, 6).toString('ascii') === 'GIF89a') {
+    return 'image/gif'
+  }
+  if (image.subarray(0, 4).toString('ascii') === 'RIFF' && image.subarray(8, 12).toString('ascii') === 'WEBP') {
+    return 'image/webp'
+  }
+  return 'image/png'
+}

--- a/api/src/controllers/TeamsController.ts
+++ b/api/src/controllers/TeamsController.ts
@@ -1,4 +1,4 @@
-import { Body, Controller, Delete, FormField, Get, OperationId, Path, Post, Produces, Put, Query, Route, SuccessResponse, UploadedFile } from "tsoa"
+import { Body, Controller, Delete, FormField, Get, NoSecurity, OperationId, Path, Post, Produces, Put, Query, Route, SuccessResponse, UploadedFile } from "tsoa"
 import { Readable } from "stream"
 import { ItemsWithPagination } from "@/base/types"
 import { TeamApiModel } from "@/models/contract/TeamApiModel"
@@ -9,6 +9,7 @@ import Player from "@/models/Player"
 import { getAllStatsForAllTeams, getAllStatsForTeam } from "@/services/TeamStatsService"
 import { fetchTeamLogo, replaceTeamLogo, LOGO_CACHE_SECONDS } from "@/services/TeamService"
 import { Op } from "sequelize"
+import { detectImageMimeType } from "@/base/FileUtils"
 
 @Route("teams")
 export class TeamsController extends Controller {
@@ -112,11 +113,13 @@ export class TeamsController extends Controller {
    * @param teamId The team whose logo to download
    */
   @Get("{teamId}/logo")
+  @NoSecurity()
   @OperationId("getTeamLogo")
   @Produces("image/png")
   public async getTeamLogo(@Path() teamId: number): Promise<Readable> {
     const logo = await fetchTeamLogo(teamId)
 
+    this.setHeader('Content-Type', detectImageMimeType(logo))
     this.setHeader('Cache-Control', `public, max-age=${LOGO_CACHE_SECONDS}`)
     return Readable.from(logo)
   }

--- a/api/tests/api/teams.test.ts
+++ b/api/tests/api/teams.test.ts
@@ -11,6 +11,8 @@ import { givenPlayerExists, cleanupPlayer } from '@tests/api/common-players'
 const WHOLE_TEAM_LIST = 500
 /** Real country with no bootstrap teams, used to isolate this suite's list fixtures. */
 const TEAM_FIXTURE_COUNTRY = 'Antarctica'
+/** Bootstrap team whose stored logo is always available. */
+const BOOTSTRAP_TEAM_WITH_LOGO_ID = 1
 
 
 describe('Teams', () => {
@@ -191,6 +193,17 @@ describe('Teams', () => {
       // endpoint rather than carrying tens of kilobytes of base64.
       expect(entry.team.logo_url).toBe(`/api/teams/${teamId}/logo`)
       expect(JSON.stringify(entry.team)).not.toContain('data:image')
+    })
+
+    it('serves the bootstrap logo without API client authentication', async () => {
+      const response = await fetch(
+        `${process.env.API_BASE_URL || 'http://localhost:8000/api'}/teams/${BOOTSTRAP_TEAM_WITH_LOGO_ID}/logo`,
+      )
+      const logo = await response.arrayBuffer()
+
+      expect(response.status).toBe(200)
+      expect(response.headers.get('content-type')).toContain('image/')
+      expect(logo.byteLength).toBeGreaterThan(0)
     })
 
     it('reports the same totals as GET /teams/:id/stats', async () => {

--- a/ui/.env.template
+++ b/ui/.env.template
@@ -1,2 +1,5 @@
 # JWT Secret used for signing and verifying JSON Web Tokens
 JWT_SECRET=my-secret-key
+
+# Public API base URL used by the generated client and API-hosted images
+NEXT_PUBLIC_API_BASE_URL=http://localhost:8000/api

--- a/ui/app/api/client.ts
+++ b/ui/app/api/client.ts
@@ -2,7 +2,7 @@ import { VavalMApi } from "@/api/generated/VavalMApi"
 
 // Create an API client for tests
 export const VavalMApiClient = new VavalMApi({
-  BASE: process.env.API_BASE_URL || 'http://localhost:8000/api',
+  BASE: process.env.NEXT_PUBLIC_API_BASE_URL || 'http://localhost:8000/api',
   // For tests, we can add a dummy token or set up JWT as needed
   TOKEN: process.env.TEST_API_TOKEN || 'test-token',
 })

--- a/ui/app/api/models/constants.ts
+++ b/ui/app/api/models/constants.ts
@@ -8,7 +8,20 @@ export const CACHE_DURATION_MS: number = 60000 // 1 minute
  * @returns The base URL of the API
  */
 export const getApiBaseUrl = (): string => {
-  return process.env.API_BASE_URL || 'http://localhost:8000/api'
+  return process.env.NEXT_PUBLIC_API_BASE_URL || 'http://localhost:8000/api'
+}
+
+/**
+ * Resolves an API-relative asset path against the configured public API host.
+ * @param assetPath The API-relative or already absolute asset URL
+ * @returns The URL the browser should request
+ */
+export const resolveApiAssetUrl = (assetPath: string): string => {
+  if (!assetPath.startsWith('/api/')) {
+    return assetPath
+  }
+
+  return `${new URL(getApiBaseUrl()).origin}${assetPath}`
 }
 
 /**

--- a/ui/app/components/common/ImageAutoSize.tsx
+++ b/ui/app/components/common/ImageAutoSize.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState, useMemo } from 'react'
 import Image, { ImageProps } from 'next/image'
 import { objectURLOrDefault } from '@/api/models/helpers'
+import { resolveApiAssetUrl } from '@/api/models/constants'
 
 type ImageAutoSizeProps = Omit<ImageProps, 'src'> & {
   imageFile?: File | null;
@@ -9,7 +10,7 @@ type ImageAutoSizeProps = Omit<ImageProps, 'src'> & {
 }
 
 const ImageAutoSize: React.FC<ImageAutoSizeProps> = (props) => {
-  const { imageFile, fallbackSrc, src, width, height, style, ...rest } = props
+  const { imageFile, fallbackSrc, src, width, height, style, unoptimized, ...rest } = props
   const [objectUrl, setObjectUrl] = useState<string | null>(null)
 
   useEffect(() => {
@@ -38,7 +39,11 @@ const ImageAutoSize: React.FC<ImageAutoSizeProps> = (props) => {
   )
 
   // Memoize the image source to prevent unnecessary re-renders
-  const imageSrc = useMemo(() => src || objectUrl || fallbackSrc || '', [src, objectUrl, fallbackSrc])
+  const imageSrc = useMemo(
+    () => resolveApiAssetUrl(src || objectUrl || fallbackSrc || ''),
+    [src, objectUrl, fallbackSrc],
+  )
+  const isApiAsset = Boolean(src?.startsWith('/api/'))
 
   return (imageSrc ? (
     <Image
@@ -47,6 +52,7 @@ const ImageAutoSize: React.FC<ImageAutoSizeProps> = (props) => {
       src={imageSrc}
       width={width}
       height={height}
+      unoptimized={unoptimized || isApiAsset}
       style={{ ...style, maxWidth: width, maxHeight: height, width: 'auto', height: 'auto' }}
     />
   ) : (

--- a/ui/next.config.js
+++ b/ui/next.config.js
@@ -1,6 +1,8 @@
 /**
  * @type {import('next').NextConfig}
  */
+const apiBaseUrl = new URL(process.env.NEXT_PUBLIC_API_BASE_URL || 'http://localhost:8000/api')
+
 const nextConfig = {
   images: {
     remotePatterns: [
@@ -23,6 +25,12 @@ const nextConfig = {
       {
         protocol: 'https',
         hostname: 'flags.restcountries.com',
+      },
+      {
+        protocol: apiBaseUrl.protocol.replace(':', ''),
+        hostname: apiBaseUrl.hostname,
+        port: apiBaseUrl.port,
+        pathname: '/api/**',
       },
     ],
   },


### PR DESCRIPTION
## Description

Team logo URLs are API-relative, so Next.js was requesting them from the UI host. Resolve those assets against the public API base URL and allow the read-only logo endpoint to load without bearer authentication, which normal image requests cannot attach. The endpoint now returns the detected image content type, and the API test verifies the persistent bootstrap logo is a public, nonempty image response.

## Validation

- [x] pnpm lint
- [x] pnpm build
- [x] pnpm test
- [x] Verified bootstrap team images render with nonzero natural dimensions