### PR TITLE
fix(ui): prevent layout shifts from scrollbars

### DIFF
--- a/ui/app/globals.css
+++ b/ui/app/globals.css
@@ -1,5 +1,9 @@
 @import "tailwindcss";
 
+html {
+  scrollbar-gutter: stable;
+}
+
 /* Additional custom styles */
 body {
   font-family: ui-sans-serif, system-ui, sans-serif;


### PR DESCRIPTION
## Description

High-volume pages add a vertical scrollbar while short and loading states remove it, changing the usable viewport width by 15px and shifting the whole UI. Reserve the scrollbar gutter globally so page and pagination transitions keep the same content width.

## Validation

- [x] `pnpm lint`
- [x] Browser measurement: short and high-volume pages both keep a 1265px content width
- [x] CI `pnpm build`
- [x] CI `pnpm test`
