### PR TITLE
fix(ui): stabilize paginated table layouts

### DIFF
--- a/ui/app/components/common/ImageAutoSize.tsx
+++ b/ui/app/components/common/ImageAutoSize.tsx
@@ -10,7 +10,7 @@ type ImageAutoSizeProps = Omit<ImageProps, 'src'> & {
 }
 
 const ImageAutoSize: React.FC<ImageAutoSizeProps> = (props) => {
-  const { imageFile, fallbackSrc, src, width, height, style, unoptimized, ...rest } = props
+  const { imageFile, fallbackSrc, src, width, height, style, unoptimized, className, ...rest } = props
   const [objectUrl, setObjectUrl] = useState<string | null>(null)
 
   useEffect(() => {
@@ -30,11 +30,11 @@ const ImageAutoSize: React.FC<ImageAutoSizeProps> = (props) => {
 
   // No Image fallback
   const NoImageFallback = () => (
-    <div className="bg-yellow-100 rounded-full mr-2">
+    <span className="flex h-full w-full items-center justify-center rounded-full bg-yellow-100">
       <svg className="w-6 h-6 text-yellow-400" fill="currentColor" viewBox="0 0 24 24">
         <path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.41 0-8-3.59-8-8s3.59-8 8-8 8 3.59 8 8-3.59 8-8 8zm1-15h-2v6h2V7zm0 8h-2v2h2v-2z" />
       </svg>
-    </div>
+    </span>
 
   )
 
@@ -45,19 +45,34 @@ const ImageAutoSize: React.FC<ImageAutoSizeProps> = (props) => {
   )
   const isApiAsset = Boolean(src?.startsWith('/api/'))
 
-  return (imageSrc ? (
-    <Image
-      {...rest}
-      alt={props.alt || 'Image'}
-      src={imageSrc}
-      width={width}
-      height={height}
-      unoptimized={unoptimized || isApiAsset}
-      style={{ ...style, maxWidth: width, maxHeight: height, width: 'auto', height: 'auto' }}
-    />
-  ) : (
-    <NoImageFallback />
-  ))
+  return (
+    <span
+      className={className}
+      style={{
+        alignItems: 'center',
+        display: 'inline-flex',
+        flexShrink: 0,
+        height,
+        justifyContent: 'center',
+        overflow: 'hidden',
+        width,
+      }}
+    >
+      {imageSrc ? (
+        <Image
+          {...rest}
+          alt={props.alt || 'Image'}
+          src={imageSrc}
+          width={width}
+          height={height}
+          unoptimized={unoptimized || isApiAsset}
+          style={{ ...style, height: '100%', objectFit: style?.objectFit || 'contain', width: '100%' }}
+        />
+      ) : (
+        <NoImageFallback />
+      )}
+    </span>
+  )
 }
 
 // Use React.memo to prevent unnecessary re-renders of this component

--- a/ui/app/components/games/GameLogsTable.tsx
+++ b/ui/app/components/games/GameLogsTable.tsx
@@ -122,7 +122,13 @@ const GameLogsTable = ({ gameId, initialRound, maxRoundNumber }: GameLogsTablePr
         <div className="text-center p-4">No logs available for this round</div>
       ) : (
         <div className="overflow-auto max-h-[60vh]">
-          <table className="min-w-full bg-white shadow-md rounded-lg overflow-hidden">
+          <table className="w-full min-w-[700px] table-fixed bg-white shadow-md rounded-lg overflow-hidden">
+            <colgroup>
+              <col style={{ width: '10%' }} />
+              <col style={{ width: '60%' }} />
+              <col style={{ width: '15%' }} />
+              <col style={{ width: '15%' }} />
+            </colgroup>
             <thead className="bg-gray-800 text-white sticky top-0">
               <tr>
                 <th className="py-2 px-4 border-b border-gray-200">Round</th>

--- a/ui/app/players/page.tsx
+++ b/ui/app/players/page.tsx
@@ -126,7 +126,16 @@ export default function ListPlayers(): React.ReactNode {
         />
         
         <div className="w-full overflow-x-auto rounded-lg shadow">
-          <table className="min-w-full">
+          <table className="w-full min-w-[1200px] table-fixed">
+            <colgroup>
+              <col style={{ width: '14%' }} />
+              <col style={{ width: '5%' }} />
+              <col style={{ width: '11%' }} />
+              <col style={{ width: '10%' }} />
+              <col style={{ width: '10%' }} />
+              <col style={{ width: '42%' }} />
+              <col style={{ width: '8%' }} />
+            </colgroup>
             <thead>
               <tr className="bg-gray-800 text-white">
                 <th className="px-5 py-3 text-left text-xs font-semibold uppercase tracking-wider">Player</th>

--- a/ui/app/players/stats/page.tsx
+++ b/ui/app/players/stats/page.tsx
@@ -94,7 +94,13 @@ const PlayersStatsPage = (): React.ReactNode => {
     <div className="flex min-h-screen flex-col items-center p-24">
       <SectionHeader title="Players Stats" />
       <div className="w-full overflow-x-auto rounded-lg shadow">
-        <table className="min-w-full">
+        <table className="w-full min-w-[1100px] table-fixed">
+          <colgroup>
+            <col style={{ width: '18%' }} />
+            <col style={{ width: '10%' }} />
+            <col span={statColumns.length} style={{ width: '5.6%' }} />
+            <col style={{ width: '5%' }} />
+          </colgroup>
           <thead>
             <tr className="bg-gray-800 text-white">
               <th className="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wider">Player</th>

--- a/ui/app/teams/page.tsx
+++ b/ui/app/teams/page.tsx
@@ -98,7 +98,14 @@ export default function ListTeams(): React.ReactNode {
       <div className="flex min-h-screen flex-col items-center p-24">
         <SectionHeader title="Teams" action={openNewTeamModal} actionText="New Team" />
         <div className="w-full overflow-x-auto rounded-lg shadow">
-          <table className="min-w-full">
+          <table className="w-full min-w-[1000px] table-fixed">
+            <colgroup>
+              <col style={{ width: '16%' }} />
+              <col style={{ width: '14%' }} />
+              <col style={{ width: '44%' }} />
+              <col style={{ width: '18%' }} />
+              <col style={{ width: '8%' }} />
+            </colgroup>
             <thead>
               <tr className="bg-gray-800 text-white">
                 <th className="px-5 py-3 text-left text-xs font-semibold uppercase tracking-wider">Team</th>

--- a/ui/app/teams/stats/page.tsx
+++ b/ui/app/teams/stats/page.tsx
@@ -89,7 +89,12 @@ const TeamsStatsPage = (): React.ReactNode => {
     <div className="flex min-h-screen flex-col items-center p-24">
       <SectionHeader title="Teams Stats" />
       <div className="w-full overflow-x-auto rounded-lg shadow">
-        <table className="min-w-full">
+        <table className="w-full min-w-[900px] table-fixed">
+          <colgroup>
+            <col style={{ width: '22%' }} />
+            <col span={statColumns.length} style={{ width: '7.2%' }} />
+            <col style={{ width: '6%' }} />
+          </colgroup>
           <thead>
             <tr className="bg-gray-800 text-white">
               <th className="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wider">Team</th>

--- a/ui/app/tournaments/[tourneyId]/page.tsx
+++ b/ui/app/tournaments/[tourneyId]/page.tsx
@@ -165,7 +165,12 @@ export default function ViewTournament(props: { params: Params }): React.ReactNo
           <h3 className="text-xl font-bold mb-2">Standings</h3>
           <hr className="mb-2" />
           <div className="overflow-x-auto">
-            <table className="min-w-full rounded-lg overflow-hidden shadow">
+            <table className="w-full min-w-[700px] table-fixed rounded-lg overflow-hidden shadow">
+              <colgroup>
+                <col style={{ width: '6%' }} />
+                <col style={{ width: '24%' }} />
+                <col span={6} style={{ width: '11.7%' }} />
+              </colgroup>
               <thead>
                 <tr className="bg-gray-800 text-white">
                   <th className="py-2 px-2 text-center text-xs font-semibold uppercase tracking-wider">#</th>
@@ -210,7 +215,14 @@ export default function ViewTournament(props: { params: Params }): React.ReactNo
           <h3 className="text-xl font-bold mb-2">Matches Schedule</h3>
           <hr className="mb-2" />
           <div className="overflow-x-auto">
-            <table className="min-w-full rounded-lg overflow-hidden shadow">
+            <table className="w-full min-w-[700px] table-fixed rounded-lg overflow-hidden shadow">
+              <colgroup>
+                <col style={{ width: '18%' }} />
+                <col style={{ width: '12%' }} />
+                <col style={{ width: '25%' }} />
+                <col style={{ width: '25%' }} />
+                <col style={{ width: '20%' }} />
+              </colgroup>
               <thead>
                 <tr className="bg-gray-800 text-white">
                   <th className="py-2 px-3 text-center text-xs font-semibold uppercase tracking-wider">Date</th>

--- a/ui/app/tournaments/page.tsx
+++ b/ui/app/tournaments/page.tsx
@@ -93,7 +93,16 @@ export default function ListTournaments(): React.ReactNode {
       <div className="flex min-h-screen flex-col items-center p-24">
         <SectionHeader title="Tournaments" action={openNewTournamentModal} actionText="New Tournament" />
         <div className="w-full overflow-x-auto rounded-lg shadow">
-          <table className="min-w-full">
+          <table className="w-full min-w-[1000px] table-fixed">
+            <colgroup>
+              <col style={{ width: '18%' }} />
+              <col style={{ width: '10%' }} />
+              <col style={{ width: '12%' }} />
+              <col style={{ width: '10%' }} />
+              <col style={{ width: '12%' }} />
+              <col style={{ width: '30%' }} />
+              <col style={{ width: '8%' }} />
+            </colgroup>
             <thead>
               <tr className="bg-gray-800 text-white">
                 <th className="px-5 py-3 text-left text-xs font-semibold uppercase tracking-wider">Tournament</th>


### PR DESCRIPTION
## Description

Paginated tables recalculated their column widths from each page's content, while shared images changed size after their intrinsic aspect ratios loaded. Reserve fixed image boxes and define stable column proportions for paginated and high-volume tables so images, text, and controls remain in place while data changes.

## Validation

- [x] `pnpm lint`
- [x] `pnpm test` — 106 tests passed
- [x] Browser pagination checks — 0px column-position delta across Players, Teams, and Players Stats pages
- [x] Browser image checks — rendered boxes retain every requested width and height
- [x] CI `pnpm build`
